### PR TITLE
[out_oracle_log_analytics] feat: Implement GZIP compression for paylo…

### DIFF
--- a/plugins/out_oracle_log_analytics/oci_logan.c
+++ b/plugins/out_oracle_log_analytics/oci_logan.c
@@ -187,8 +187,8 @@ static flb_sds_t add_header_and_signing(struct flb_http_client *c,
 }
 
 static int build_headers(struct flb_http_client *c, struct flb_oci_logan *ctx,
-                         flb_sds_t json, flb_sds_t hostname, int port,
-                         flb_sds_t uri)
+                         void *zipped_payload, size_t zipped_payload_size,
+                         flb_sds_t hostname, int port, flb_sds_t uri)
 {
     int ret = -1;
     flb_sds_t tmp_sds = NULL;
@@ -265,8 +265,9 @@ static int build_headers(struct flb_http_client *c, struct flb_oci_logan *ctx,
 
     /* Add x-content-sha256 Header */
     ret = flb_hash_simple(FLB_HASH_SHA256,
-                          (unsigned char *) json,
-                          flb_sds_len(json), sha256_buf, sizeof(sha256_buf));
+                          (unsigned char *) zipped_payload,
+                          zipped_payload_size,
+                          sha256_buf, sizeof(sha256_buf));
 
     if (ret != FLB_CRYPTO_SUCCESS) {
         flb_plg_error(ctx->ins,
@@ -311,8 +312,8 @@ static int build_headers(struct flb_http_client *c, struct flb_oci_logan *ctx,
     }
 
     /* Add content-Length */
-    tmp_len = snprintf(tmp_sds, flb_sds_alloc(tmp_sds) - 1, "%i",
-                       (int) flb_sds_len(json));
+    tmp_len = snprintf(tmp_sds, flb_sds_alloc(tmp_sds) - 1, "%zu",
+                       zipped_payload_size); 
     flb_sds_len_set(tmp_sds, tmp_len);
     signing_str = add_header_and_signing(c, signing_str,
                                          FLB_OCI_HEADER_CONTENT_LENGTH,
@@ -631,7 +632,7 @@ static flb_sds_t compose_uri(struct flb_oci_logan *ctx,
     flb_sds_cat_safe(&uri_param, FLB_OCI_PAYLOAD_TYPE,
                      sizeof(FLB_OCI_PAYLOAD_TYPE) - 1);
     flb_sds_cat_safe(&uri_param, "=", 1);
-    flb_sds_cat_safe(&uri_param, "JSON", 4);
+    flb_sds_cat_safe(&uri_param, "GZIP", 4);
 
 
     if (!uri_param) {
@@ -978,52 +979,62 @@ struct flb_http_client *create_oci_signed_request_for_logging(struct
     return NULL;
 }
 
-static void dump_payload_to_file(struct flb_oci_logan *ctx, flb_sds_t payload,
-                                 flb_sds_t log_group_id)
+static void dump_payload_to_file(struct flb_oci_logan *ctx, 
+                                 const void *payload, 
+                                 size_t payload_size,
+                                 flb_sds_t log_group_id,
+                                 const char *suffix)
 {
     char hash_in_hex[66];
     char filename[1024];
-    char *content_sha256;
-    int i;
-    size_t payload_size;
-    FILE *fp;
+    FILE *fp = NULL;
 
     if (!ctx->payload_files_location) {
-        flb_plg_error(ctx->ins,
-                      "directory path for dumping should be specified");
+        flb_plg_error(ctx->ins, "directory path for dumping should be specified");
         return;
     }
-    payload_size = flb_sds_len(payload);
-    content_sha256 = calculate_content_sha256_b64(payload, payload_size);
+    
+    char *content_sha256 = calculate_content_sha256_b64(payload, payload_size);
     if (!content_sha256) {
         return;
     }
 
-    for (i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-        sprintf(hash_in_hex + (i * 2), "%02x", content_sha256[i]);
+    // Create hex hash for filename
+    int i;
+    for(i = 0; i < 16 && i < strlen(content_sha256); i++) {
+        sprintf(hash_in_hex + (i * 2), "%02x", (unsigned char)content_sha256[i]);
     }
 
-    snprintf(filename, sizeof(filename), "%s/%s_%.12s.json",
-             ctx->payload_files_location, log_group_id, hash_in_hex);
-
+    snprintf(filename, sizeof(filename), "%s/%s_%.12s_%s.dat",
+             ctx->payload_files_location, log_group_id, hash_in_hex, suffix);
+    
     if (access(filename, F_OK) == 0) {
-        flb_plg_debug(ctx->ins, "payload s already dumped to->%s", filename);
+        flb_plg_debug(ctx->ins, "%s payload already dumped to: %s", suffix, filename);
         flb_free(content_sha256);
         return;
     }
-
-    fp = fopen(filename, "w");
+    
+    fp = fopen(filename, "wb");
     if (!fp) {
-        flb_plg_error(ctx->ins, "cant open file -> %s", filename);
+        flb_plg_error(ctx->ins, "can't open file: %s", filename);
         flb_free(content_sha256);
         return;
     }
-
-    fprintf(fp, "%s", payload);
+    
+    fwrite(payload, 1, payload_size, fp);
     fclose(fp);
     flb_free(content_sha256);
+    
+    flb_plg_info(ctx->ins, "%s payload (%zu bytes) dumped to: %s", 
+                 suffix, payload_size, filename);
+}
 
-    flb_plg_info(ctx->ins, "payload dumped to: %s", filename);
+static void dump_compressed_payload_to_file(struct flb_oci_logan *ctx, 
+                                           const void *compressed_payload, 
+                                           size_t compressed_size,
+                                           flb_sds_t log_group_id)
+{
+    dump_payload_to_file(ctx, compressed_payload, compressed_size, log_group_id, "compressed");
 }
 
 static int flush_to_endpoint(struct flb_oci_logan *ctx,
@@ -1036,62 +1047,96 @@ static int flush_to_endpoint(struct flb_oci_logan *ctx,
     flb_sds_t full_uri;
     struct flb_http_client *c = NULL;
     struct flb_connection *u_conn;
-    bool should_retry;
+    bool compressed = FLB_FALSE;
+    void *payload_buf = NULL;
+    size_t payload_size = 0;
+    int compress_ret = 0;
+    bool should_retry = 0;
+    // struct timespec start, end;
+    // double elapsed;
 
     if (!payload) {
         return FLB_ERROR;
     }
-    if (ctx->dump_payload_file) {
-        dump_payload_to_file(ctx, payload, log_group_id);
-    }
-    full_uri = compose_uri(ctx, log_set_id, log_group_id);
-    if (!full_uri) {
-        flb_plg_error(ctx->ins,
-                      "unable to compose uri for logGroup: %s logSet: %s",
-                      ctx->oci_la_log_group_id, ctx->oci_la_log_set_id);
-        return FLB_ERROR;
+
+    payload_buf = (void *) payload;
+    payload_size = flb_sds_len(payload);
+    // clock_gettime(CLOCK_MONOTONIC, &start);
+    compress_ret = flb_gzip_compress((void *) payload, flb_sds_len(payload),
+                                    &payload_buf, &payload_size);
+    // clock_gettime(CLOCK_MONOTONIC, &end);
+    // elapsed = (end.tv_sec - start.tv_sec) * 1000.0 + 
+    //              (end.tv_nsec - start.tv_nsec) / 1000000.0;
+    // FILE *fp_log = fopen("/tmp/compression.log", "a");
+
+    // fprintf(fp_log, "elpased in ms -> %.3f\n", elapsed);
+    // fflush(fp_log);
+    if (compress_ret == 0) {
+        compressed = FLB_TRUE;
+        flb_plg_debug(ctx->ins, "gzip: %zu -> %zu bytes (%.1f%% reduction)", 
+                      flb_sds_len(payload), payload_size,
+                      100.0 * (1.0 - ((double)payload_size / flb_sds_len(payload))));
+    } else {
+        flb_plg_debug(ctx->ins, "gzip compression failed, using original payload");
+        compressed = FLB_FALSE;
+        payload_buf = (void *) payload;
+        payload_size = flb_sds_len(payload);
     }
 
-    flb_plg_debug(ctx->ins, "full_uri=%s", full_uri);
+    flb_plg_info(ctx->ins, "Sending payload: size=%zu, compressed=%s", 
+                 payload_size, compressed ? "true" : "false");
+
+    if (ctx->dump_payload_file) {
+        dump_payload_to_file(ctx, payload, flb_sds_len(payload), log_group_id, "original");
+        if (compressed == FLB_TRUE) {
+            dump_compressed_payload_to_file(ctx, payload_buf, payload_size, log_group_id);
+        }
+    }
+
+    full_uri = compose_uri(ctx, log_set_id, log_group_id);
+    if (!full_uri) {
+        flb_plg_error(ctx->ins, "unable to compose uri");
+        if (compressed && payload_buf != (void *)payload) {
+            flb_free(payload_buf);
+        }
+        return FLB_ERROR;
+    }
 
     u_conn = flb_upstream_conn_get(ctx->u);
     if (!u_conn) {
         flb_sds_destroy(full_uri);
+        if (compressed && payload_buf != (void *)payload) {
+            flb_free(payload_buf);
+        }
         return FLB_ERROR;
     }
-    should_retry = 0;
+
+    // Create HTTP client based on auth type
     if (strcmp(ctx->auth_type, "instance_principal") == 0) {
-        c = create_oci_signed_request_for_logging(ctx, u_conn,
-                                                  full_uri,
+        c = create_oci_signed_request_for_logging(ctx, u_conn, full_uri,
                                                   ctx->ins->host.name,
                                                   ctx->ins->host.port,
-                                                  payload,
-                                                  (payload ?
-                                                   flb_sds_len(payload) : 0),
+                                                  payload_buf, payload_size,
                                                   &should_retry);
         if (!c) {
-            flb_plg_error(ctx->ins,
-                          "failed to create instance principal client for logging");
+            flb_plg_error(ctx->ins, "failed to create instance principal client");
             out_ret = should_retry ? FLB_RETRY : FLB_ERROR;
             goto error_label;
         }
     }
     else {
-        c = flb_http_client(u_conn, FLB_HTTP_POST, full_uri, (void *) payload,
-                            flb_sds_len(payload), ctx->ins->host.name,
-                            ctx->ins->host.port, ctx->proxy, 0);
+        c = flb_http_client(u_conn, FLB_HTTP_POST, full_uri, payload_buf, payload_size,
+                           ctx->ins->host.name, ctx->ins->host.port, ctx->proxy, 0);
         if (!c) {
-            flb_plg_error(ctx->ins,
-                          "failed to config file client for logging");
+            flb_plg_error(ctx->ins, "failed to create config file client");
             goto error_label;
         }
+        
         flb_http_allow_duplicated_headers(c, FLB_FALSE);
-
         flb_http_buffer_size(c, FLB_HTTP_DATA_SIZE_MAX);
 
-        if (build_headers
-            (c, ctx, payload, ctx->ins->host.name, ctx->ins->host.port,
-             full_uri) < 0) {
+        if (build_headers(c, ctx, payload_buf, payload_size,
+                         ctx->ins->host.name, ctx->ins->host.port, full_uri) < 0) {
             flb_plg_error(ctx->ins, "failed to build headers");
             goto error_label;
         }
@@ -1103,20 +1148,15 @@ static int flush_to_endpoint(struct flb_oci_logan *ctx,
     }
 
     out_ret = FLB_OK;
-
     http_ret = flb_http_do(c, &b_sent);
 
     if (http_ret == 0) {
         if (c->resp.status != 200) {
-            flb_plg_debug(ctx->ins, "request header %s", c->header_buf);
-
             out_ret = FLB_ERROR;
-
             if (c->resp.payload && c->resp.payload_size > 0) {
                 if (retry_error(c, ctx) == FLB_TRUE) {
                     out_ret = FLB_RETRY;
                 }
-
                 flb_plg_error(ctx->ins, "%s:%i, retry=%s, HTTP status=%i\n%s",
                               ctx->ins->host.name, ctx->ins->host.port,
                               (out_ret == FLB_RETRY ? "true" : "false"),
@@ -1130,38 +1170,33 @@ static int flush_to_endpoint(struct flb_oci_logan *ctx,
             }
         }
         else {
-            flb_plg_debug(ctx->ins, "data -> [%s]\theaders->[%s]",
-                          c->resp.data, c->resp.headers_end);
-            flb_plg_info(ctx->ins, "log sent to oci   with success");
+            flb_plg_info(ctx->ins, "log sent to OCI with success");
         }
     }
     else {
         out_ret = FLB_RETRY;
-        flb_plg_error(ctx->ins,
-                      "could not flush records to %s:%i (http_do=%i), retry=%s",
+        flb_plg_error(ctx->ins, "could not flush records to %s:%i (http_do=%i), retry=%s",
                       ctx->ins->host.name, ctx->ins->host.port, http_ret,
                       (out_ret == FLB_RETRY ? "true" : "false"));
         goto error_label;
     }
 
-  error_label:
+error_label:
     if (full_uri) {
         flb_sds_destroy(full_uri);
     }
-
-    /* Destroy HTTP client context */
     if (c) {
         flb_http_client_destroy(c);
     }
-
-    /* Release the TCP connection */
     if (u_conn) {
         flb_upstream_conn_release(u_conn);
     }
-
+    if (compressed && payload_buf != (void *)payload) {
+        flb_free(payload_buf);
+    }
+    
     return out_ret;
 }
-
 
 static void pack_oci_fields(msgpack_packer *packer, struct flb_oci_logan *ctx,
                             char *tag, int tag_len)

--- a/plugins/out_oracle_log_analytics/oci_logan.h
+++ b/plugins/out_oracle_log_analytics/oci_logan.h
@@ -188,6 +188,7 @@
 #include <fluent-bit/flb_hash.h>
 #include <fluent-bit/flb_sds.h>
 #include <monkey/mk_core/mk_list.h>
+#include <fluent-bit/flb_gzip.h>
 #include <fluent-bit/flb_jsmn.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
@@ -316,3 +317,4 @@ const char *get_domain_suffix_for_realm(const char *realm);
 const char *determine_realm_from_region(const char *region);
 const char *long_region_name(char *short_region_name);
 #endif
+


### PR DESCRIPTION
…ads compression

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
This pull request introduces gzip compression for payloads sent to Oracle Log Analytics, improving network efficiency and supporting the new expected payload format. It also refactors payload dumping for better debugging and updates header and URI handling to match the new compressed payloads. Several improvements and bug fixes are included to ensure proper resource cleanup and more informative logging.

**Payload Compression and Transmission:**
- Payloads are now compressed using gzip before being sent. The code attempts compression and falls back to the original payload if compression fails. The payload type in the URI is updated from `JSON` to `GZIP` to reflect this change. (`[[1]](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L1039-R1139)`, `[[2]](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L634-R635)`, `[[3]](diffhunk://#diff-c65d60d1aa5ad50f640d872209e1e4f68abbd61ab75e3b258a1937e378e0b9aaR191)`)

**Header and Content-Length Handling:**
- The `build_headers` function and related calls are updated to use the compressed payload and its size for SHA256 hashing and the `Content-Length` header, ensuring correct request metadata. (`[[1]](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L190-R191)`, `[[2]](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L268-R270)`, `[[3]](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L314-R316)`)

**Payload Dumping and Debugging Enhancements:**
- The payload dumping logic is refactored to support both original and compressed payloads, writing them as binary files with improved file naming and logging for easier debugging. (`[plugins/out_oracle_log_analytics/oci_logan.cL981-R1037](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L981-R1037)`)

**Resource Management and Error Handling:**
- The code now ensures that memory allocated for compressed payloads is properly freed and that all resources are cleaned up in error cases, reducing the risk of memory leaks. (`[plugins/out_oracle_log_analytics/oci_logan.cL1151-L1165](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L1151-L1165)`)

**Logging and Code Cleanliness:**
- Logging is clarified and redundant debug statements are removed or improved for better maintainability and readability. (`[[1]](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L1106-L1119)`, `[[2]](diffhunk://#diff-81a068290e9bdd10163cce2b30b61dff7aee9f6ca351196d473d03cbd6d8ead5L1133-R1178)`)

These changes collectively improve the reliability, efficiency, and maintainability of the Oracle Log Analytics output plugin for Fluent Bit.
- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
